### PR TITLE
Update RightAngleLinkWidget.tsx

### DIFF
--- a/packages/react-diagrams-routing/src/link/RightAngleLinkWidget.tsx
+++ b/packages/react-diagrams-routing/src/link/RightAngleLinkWidget.tsx
@@ -188,6 +188,7 @@ export class RightAngleLinkWidget extends React.Component<RightAngleLinkProps, R
 		//ensure id is present for all points on the path
 		let points = this.props.link.getPoints();
 		let paths = [];
+		this.refPaths = [];
 
 		// Get points based on link orientation
 		let pointLeft = points[0];
@@ -286,7 +287,6 @@ export class RightAngleLinkWidget extends React.Component<RightAngleLinkProps, R
 			);
 		}
 
-		this.refPaths = [];
 		return <g data-default-link-test={this.props.link.getOptions().testName}>{paths}</g>;
 	}
 }


### PR DESCRIPTION
The method link.getRenderedPath() always returns an empty array.

# Checklist

- [x] The tests pass
- [x] I have referenced the issue(s) or other PR(s) this fixes/relates-to
- [x] I have run ```pnpm changeset``` and followed the instructions
- [x] I have explained in this PR, what I did and why
- [-] I replaced the image below
- [x] Had a beer/coffee/tea because I did something cool today

## What, why and how?
The getRenderedPath method returns an empty array all the time. for RightAngle links. And this edit fix this problem.